### PR TITLE
Web Request to automatically get newest release tag/version

### DIFF
--- a/Services/ModService.cs
+++ b/Services/ModService.cs
@@ -47,12 +47,11 @@ namespace tModloaderDiscordBot.Services
 
 		public async Task Initialize()
 		{
-			var client = new WebClient();
+			using var client = new WebClient();
 			//The Github api expects at least more than 5 letters here, change it to whatever you want
 			client.Headers.Add("user-agent", "Discord.Net");
 			
 			tMLVersion = $"tModLoader {JObject.Parse(client.DownloadString(NewestReleaseUrl)).GetValue("tag_name")}";
-			client.Dispose();
 			_semaphore = new SemaphoreSlim(1, 1);
 
 			//if (_updateTimer == null)

--- a/Services/ModService.cs
+++ b/Services/ModService.cs
@@ -24,6 +24,7 @@ namespace tModloaderDiscordBot.Services
 		internal const string HomepageUrl = "http://javid.ddns.net/tModLoader/moddescription.php";
 		internal const string PopularUrl = "http://javid.ddns.net/tModLoader/tools/populartop10.php";
 		internal const string HotUrl = "http://javid.ddns.net/tModLoader/tools/hottop10.php";
+		internal const string NewestReleaseUrl = "https://api.github.com/repos/tModLoader/tModLoader/releases/latest";
 
 		private static string ModDir => "mods";
 		internal static string tMLVersion;
@@ -50,7 +51,7 @@ namespace tModloaderDiscordBot.Services
 			//The Github api expects at least more than 5 letters here, change it to whatever you want
 			client.Headers.Add("user-agent", "Discord.Net");
 			
-			tMLVersion = JObject.Parse(client.DownloadString(@"https://api.github.com/repos/tModLoader/tModLoader/releases/latest")).GetValue("tag_name").ToString();
+			tMLVersion = JObject.Parse(client.DownloadString(NewestReleaseUrl)).GetValue("tag_name").ToString();
 			_semaphore = new SemaphoreSlim(1, 1);
 
 			//if (_updateTimer == null)

--- a/Services/ModService.cs
+++ b/Services/ModService.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.IO.Compression;
 using System.Linq;
+using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
 using Discord;
@@ -45,7 +46,11 @@ namespace tModloaderDiscordBot.Services
 
 		public async Task Initialize()
 		{
-			tMLVersion = "v0.11.7.7";
+			var client = new WebClient();
+			//The Github api expects at least more than 5 letters here, change it to whatever you want
+			client.Headers.Add("user-agent", "Discord.Net");
+			
+			tMLVersion = JObject.Parse(client.DownloadString(@"https://api.github.com/repos/tModLoader/tModLoader/releases/latest")).GetValue("tag_name").ToString();
 			_semaphore = new SemaphoreSlim(1, 1);
 
 			//if (_updateTimer == null)

--- a/Services/ModService.cs
+++ b/Services/ModService.cs
@@ -52,6 +52,7 @@ namespace tModloaderDiscordBot.Services
 			client.Headers.Add("user-agent", "Discord.Net");
 			
 			tMLVersion = JObject.Parse(client.DownloadString(NewestReleaseUrl)).GetValue("tag_name").ToString();
+			client.Dispose();
 			_semaphore = new SemaphoreSlim(1, 1);
 
 			//if (_updateTimer == null)

--- a/Services/ModService.cs
+++ b/Services/ModService.cs
@@ -51,7 +51,7 @@ namespace tModloaderDiscordBot.Services
 			//The Github api expects at least more than 5 letters here, change it to whatever you want
 			client.Headers.Add("user-agent", "Discord.Net");
 			
-			tMLVersion = JObject.Parse(client.DownloadString(NewestReleaseUrl)).GetValue("tag_name").ToString();
+			tMLVersion = $"tModLoader {JObject.Parse(client.DownloadString(NewestReleaseUrl)).GetValue("tag_name")}";
 			client.Dispose();
 			_semaphore = new SemaphoreSlim(1, 1);
 


### PR DESCRIPTION
This basically just creates a new Webclient and downloads the new newest release api data, then it gets the `tag_name` value and sets that as the tMLVersion