### PR TITLE
Mod widget rework

### DIFF
--- a/Modules/DefaultModule.cs
+++ b/Modules/DefaultModule.cs
@@ -74,7 +74,7 @@ namespace tModloaderDiscordBot.Modules
 
 					using (var client = new System.Net.Http.HttpClient())
 					{
-						var response = await client.GetByteArrayAsync($"{ModService.WidgetUrl}{modFound}.png");
+						var response = await client.GetByteArrayAsync($"{ModService.WidgetUrl}{modFound}");
 						using (var stream = new MemoryStream(response))
 						{
 							await Context.Channel.SendFileAsync(stream, $"widget-{modFound}.png");

--- a/Services/ModService.cs
+++ b/Services/ModService.cs
@@ -17,7 +17,7 @@ namespace tModloaderDiscordBot.Services
 	{
 		internal const string QueryDownloadUrl = "http://javid.ddns.net/tModLoader/tools/querymoddownloadurl.php?modname=";
 		internal const string QueryHomepageUrl = "http://javid.ddns.net/tModLoader/tools/querymodhomepage.php?modname=";
-		internal const string WidgetUrl = "https://bettermodwidget.projectagon.repl.co/?mod=";
+		internal const string WidgetUrl = "https://bettermodwidget.javidpack.repl.co/?mod=";
 		internal const string XmlUrl = "http://javid.ddns.net/tModLoader/listmods.php";
 		internal const string ModInfoUrl = "http://javid.ddns.net/tModLoader/tools/modinfo.php";
 		internal const string HomepageUrl = "http://javid.ddns.net/tModLoader/moddescription.php";

--- a/Services/ModService.cs
+++ b/Services/ModService.cs
@@ -17,7 +17,7 @@ namespace tModloaderDiscordBot.Services
 	{
 		internal const string QueryDownloadUrl = "http://javid.ddns.net/tModLoader/tools/querymoddownloadurl.php?modname=";
 		internal const string QueryHomepageUrl = "http://javid.ddns.net/tModLoader/tools/querymodhomepage.php?modname=";
-		internal const string WidgetUrl = "http://javid.ddns.net/tModLoader/widget/widgetimage/";
+		internal const string WidgetUrl = "https://bettermodwidget.projectagon.repl.co/?mod=";
 		internal const string XmlUrl = "http://javid.ddns.net/tModLoader/listmods.php";
 		internal const string ModInfoUrl = "http://javid.ddns.net/tModLoader/tools/modinfo.php";
 		internal const string HomepageUrl = "http://javid.ddns.net/tModLoader/moddescription.php";


### PR DESCRIPTION
I had a day off yesterday and decided to completely recreate the currently bland mod widget design.

### Old widget design

![Old widget design](https://i.imgur.com/YwKeTZR.png)

### New widget design

![New widget design](https://i.imgur.com/beHDCnA.png)

### Details

I'm hosting the program that creates this new widget on [repl.it](https://repl.it). Repl.it is pretty good for uptime, and it doesn't cost me anything to keep this up forever. Additionally, I made sure that this new widget generation service works in almost the exact same way as the current one, meaning minimal things were changed in this PR to support it.

It uploads the generated widget to Imgur and returns the raw image URL, just like the current ones does. If Imgur is down/rate-limiting the bot, it will use the last cached widget.