### PR TITLE
Json file autopasting

### DIFF
--- a/Services/HastebinService.cs
+++ b/Services/HastebinService.cs
@@ -68,7 +68,7 @@ namespace tModloaderDiscordBot.Services
 			var attachents = message.Attachments;
 			if(attachents.Count == 1 && attachents.ElementAt(0) is Attachment attachment)
 			{
-				if (attachment.Filename.EndsWith(".log") || attachment.Filename.EndsWith(".cs") || attachment.Filename.EndsWith(".json") && attachment.Size < 100000)
+				if ((attachment.Filename.EndsWith(".log") || attachment.Filename.EndsWith(".cs") || attachment.Filename.EndsWith(".json")) && attachment.Size < 100000)
 				{
 					using (var client = new HttpClient())
 						contents = await client.GetStringAsync(attachment.Url);


### PR DESCRIPTION
### Description
Haven't tested this, but theoretically should work. Adds issue #10.
Automatically converts files with the `.json` file extension to hastebin links.