### PR TITLE
Add message.txt to autohaste

### DIFF
--- a/Services/HastebinService.cs
+++ b/Services/HastebinService.cs
@@ -68,7 +68,7 @@ namespace tModloaderDiscordBot.Services
 			var attachents = message.Attachments;
 			if(attachents.Count == 1 && attachents.ElementAt(0) is Attachment attachment)
 			{
-				if ((attachment.Filename.EndsWith(".log") || attachment.Filename.EndsWith(".cs") || attachment.Filename.EndsWith(".json")) && attachment.Size < 100000)
+				if ((attachment.Filename.EndsWith(".log") || attachment.Filename.EndsWith(".cs") || attachment.Filename.EndsWith(".json") || attachment.Filename == "message.txt") && attachment.Size < 100000)
 				{
 					using (var client = new HttpClient())
 						contents = await client.GetStringAsync(attachment.Url);


### PR DESCRIPTION
### Description
Automatically autopaste/hastes `message.txt` files and sends the generated link to chat.
Adds issue #26.
Disclaimer: I have not tested this, but merely assumed it should work. 