### PR TITLE
Microsoft documentation search command

### DIFF
--- a/Modules/DefaultModule.cs
+++ b/Modules/DefaultModule.cs
@@ -108,6 +108,17 @@ namespace tModloaderDiscordBot.Modules
 			await ReplyAsync($"ExampleMod results for {searchTerm}: <https://github.com/tModLoader/tModLoader/search?utf8=✓&q={encoded}+path:ExampleMod&type=Code>");
 		}
 
+		[Command("microsoftdocs")]
+		[Alias("msdn", "microsoft")]
+		[Summary("Generates a search for a term in Microsoft documentation.")]
+		[Remarks("msdn <search term>\nmicrosoft Int16")]
+		public async Task MsdnSearch([Remainder]string searchTerm)
+		{
+			searchTerm = searchTerm.Trim();
+			var encoded = WebUtility.UrlEncode(searchTerm);
+			await ReplyAsync($"Microsoft docs for {searchTerm}: <https://docs.microsoft.com/en-us/search/?scope=.NET&terms={encoded}>");
+		}
+
 		[Command("ranksbysteamid")]
 		[Alias("ranksbyauthor", "listmods")]
 		[Summary("Generates a link for the ranksbysteamid of the steamid64 provided.")]

--- a/Modules/DefaultModule.cs
+++ b/Modules/DefaultModule.cs
@@ -237,17 +237,6 @@ namespace tModloaderDiscordBot.Modules
 				}
 			}
 		}
-		
-		[Command("microsoftdocs")]
-		[Alias("msdn", "microsoft")]
-		[Summary("Generates a search for the Microsoft documentation")]
-		[Remarks("microsoftdocs <search term>\microsoftdocs Int16")]
-		public async Task MicrosoftDocSearch([Remainder]string searchTerm)
-		{
-			searchTerm = searchTerm.Trim();
-			string encoded = System.Net.WebUtility.UrlEncode(searchTerm);
-			await ReplyAsync($"Microsoft Documentation results for {searchTerm}: <https://docs.microsoft.com/en-us/search/?scope=.NET&terms={encoded}>");
-		}
 
 		[Command("mod")]
 		[Alias("modinfo")]

--- a/Modules/DefaultModule.cs
+++ b/Modules/DefaultModule.cs
@@ -226,6 +226,17 @@ namespace tModloaderDiscordBot.Modules
 				}
 			}
 		}
+		
+		[Command("microsoftdocs")]
+		[Alias("msdn", "microsoft")]
+		[Summary("Generates a search for the Microsoft documentation")]
+		[Remarks("microsoftdocs <search term>\microsoftdocs Int16")]
+		public async Task MicrosoftDocSearch([Remainder]string searchTerm)
+		{
+			searchTerm = searchTerm.Trim();
+			string encoded = System.Net.WebUtility.UrlEncode(searchTerm);
+			await ReplyAsync($"Microsoft Documentation results for {searchTerm}: <https://docs.microsoft.com/en-us/search/?scope=.NET&terms={encoded}>");
+		}
 
 		[Command("mod")]
 		[Alias("modinfo")]


### PR DESCRIPTION
### Description
Command that searches the Microsoft docs with either `microsoftdocs <search term>`, `microsoft <search term>`, or `msdn <search term>`.
Adds #19 

![image](https://user-images.githubusercontent.com/45357714/131931781-74462671-a398-4952-b70b-4fe0d97fc567.png)
