### PR TITLE
1.4 support

### DIFF
--- a/Modules/DefaultModule.cs
+++ b/Modules/DefaultModule.cs
@@ -446,7 +446,7 @@ namespace tModloaderDiscordBot.Modules
 		{
 			try
 			{
-				var authorJson = await AuthorService.DownloadSingleLegacyData(steamID);
+				string authorJson = await AuthorService.DownloadSingleLegacyData(steamID);
 				JObject authorJData;
 				try
 				{
@@ -480,9 +480,9 @@ namespace tModloaderDiscordBot.Modules
 					});
 					//.WithUrl($"https://steamcommunity.com/profiles/{authorData.steamID}/");
 
-				eb.AddField("Total mod count", authorData.total ?? 0);
-				eb.AddField("Total downloads count", authorData.downloadsTotal ?? 0);
-				eb.AddField("Daily download count", authorData.downloadsYesterday ?? 0);
+				eb.AddField("Total mod count", authorData.total ?? 0, true);
+				eb.AddField("Total downloads count", authorData.downloadsTotal ?? 0, true);
+				eb.AddField("Daily download count", authorData.downloadsYesterday ?? 0, true);
 
 				string mods = string.Join(", ", authorData.mods
 					.Select(mod => mod?["display_name"]?.Value<string>()));
@@ -515,7 +515,7 @@ namespace tModloaderDiscordBot.Modules
 		{
 			try
 			{
-				var authorJson = await AuthorService.DownloadSingleData(steamID);
+				string authorJson = await AuthorService.DownloadSingleData(steamID);
 				JObject authorJData;
 				try
 				{
@@ -550,9 +550,9 @@ namespace tModloaderDiscordBot.Modules
 					.WithUrl($"https://steamcommunity.com/profiles/{authorData.steamID}/");
 
 				eb.AddField("Total mod Count", authorData.total ?? 0);
-				eb.AddField("Total downloads Count", authorData.totalDownloads ?? 0);
-				eb.AddField("Total view Count", authorData.totalViews ?? 0);
-				eb.AddField("Total favorites Count", authorData.totalFavorites);
+				eb.AddField("Total downloads Count", authorData.totalDownloads ?? 0, true);
+				eb.AddField("Total view Count", authorData.totalViews ?? 0, true);
+				eb.AddField("Total favorites Count", authorData.totalFavorites, true);
 
 				string mods = string.Join(", ", authorData.mods
 					.Select(mod =>

--- a/Modules/DefaultModule.cs
+++ b/Modules/DefaultModule.cs
@@ -344,7 +344,8 @@ namespace tModloaderDiscordBot.Modules
 				}
 				catch
 				{
-					await ReplyAsync(modJson);
+					await ReplyAsync("an error occured when parsing JSON");
+					Console.WriteLine($"{nameof(DefaultModule)}.{nameof(Mod)}: Error when parsing json. Server response was:\n{modJson}");
 					return;
 				}
 
@@ -431,8 +432,9 @@ namespace tModloaderDiscordBot.Modules
 				var embed = eb.Build();
 				await ReplyAsync("", embed: embed);
 			}
-			catch 
+			catch (Exception e)
 			{
+				Console.WriteLine($"{nameof(DefaultModule)}.{nameof(Mod)}: An error occured generating the embed: {e.Message}\n{e.StackTrace}");
 				await ReplyAsync("an error occured generating the embed");
 			}
 		}
@@ -452,9 +454,10 @@ namespace tModloaderDiscordBot.Modules
 				{
 					authorJData = JObject.Parse(authorJson);
 				}
-				catch (Exception e)
+				catch
 				{
-					await ReplyAsync($"an error occured when trying to parse Data: ```\n{authorJson}\n```");
+					await ReplyAsync("an error occured when parsing JSON");
+					Console.WriteLine($"{nameof(DefaultModule)}.{nameof(LegacyAuthor)}: Error when parsing json. Server response was:\n{authorJson}");
 					return;
 				}
 
@@ -502,7 +505,8 @@ namespace tModloaderDiscordBot.Modules
 			}
 			catch (Exception e)
 			{
-				await ReplyAsync($"an error occured generating the embed:\n```\n{e.Message}\n{e.StackTrace}\n```");
+				Console.WriteLine($"{nameof(DefaultModule)}.{nameof(LegacyAuthor)}: An error occured generating the embed: {e.Message}\n{e.StackTrace}");
+				await ReplyAsync("an error occured generating the embed");
 			}
 		}
 		
@@ -523,7 +527,8 @@ namespace tModloaderDiscordBot.Modules
 				}
 				catch (Exception e)
 				{
-					await ReplyAsync($"an error occured when trying to parse Data: ```\n{authorJson}\n```");
+					await ReplyAsync("an error occured when parsing JSON");
+					Console.WriteLine($"{nameof(DefaultModule)}.{nameof(Author)}: Error when parsing json. Server response was:\n{authorJson}");
 					return;
 				}
 
@@ -565,8 +570,9 @@ namespace tModloaderDiscordBot.Modules
 				var embed = eb.Build();
 				await ReplyAsync("", embed: embed);
 			}
-			catch
+			catch (Exception e)
 			{
+				Console.WriteLine($"{nameof(DefaultModule)}.{nameof(Author)}: An error occured generating the embed: {e.Message}\n{e.StackTrace}");
 				await ReplyAsync("an error occured generating the embed");
 			}
 		}

--- a/Modules/DefaultModule.cs
+++ b/Modules/DefaultModule.cs
@@ -143,6 +143,46 @@ namespace tModloaderDiscordBot.Modules
 			await msg.DeleteAsync();
 		}
 
+		private async Task GenerateAuthorWidget(string steamid, string widgetUrl)
+		{
+			steamid = steamid.RemoveWhitespace();
+			var msg = await ReplyAsync($"Generating widget for {steamid}...");
+			
+			using var client = new System.Net.Http.HttpClient();
+			
+			byte[] response = await client.GetByteArrayAsync($"{widgetUrl}{steamid}");
+			if (response == null)
+			{
+				await ReplyAsync($"Unable to create the widget");
+				return;
+			}
+			
+			using (var stream = new MemoryStream(response))
+			{
+				await Context.Channel.SendFileAsync(stream, $"widget-{steamid}.png");
+			}
+
+			await msg.DeleteAsync();
+		}
+		
+		[Command("author-widget")]
+		[Alias("author-widgetimg", "author-widgetimage")]
+		[Summary("Generates a widget image of the specified author")]
+		[Remarks("author-widget <steamid64>\nauthor-widget 76561198278789341")]
+		public async Task AuthorWidget([Remainder]string steamid)
+		{
+			await GenerateAuthorWidget(steamid, AuthorService.WidgetUrl);
+		}
+		
+		[Command("author-widget-legacy")]
+		[Alias("author-widgetimg-legacy", "author-widgetimage-legacy")]
+		[Summary("Generates a widget image of the specified author")]
+		[Remarks("author-widget-legacy <steamid64>\nauthor-widget-legacy 76561198278789341")]
+		public async Task LegacyAuthorWidget([Remainder]string steamid)
+		{
+			await GenerateAuthorWidget(steamid, AuthorService.LegacyWidgetUrl);
+		}
+
 		[Command("wikis")]
 		[Alias("ws")]
 		[Summary("Generates a search for a term in tModLoader wiki")]

--- a/Modules/DefaultModule.cs
+++ b/Modules/DefaultModule.cs
@@ -478,10 +478,10 @@ namespace tModloaderDiscordBot.Modules
 				eb.AddField("Favorites", $"{modData.favorited:n0}", true);
 
 				// if vote data exists
-				if (modData.voteData is { } data)
+				if (modData.voteData.HasValues)
 				{
 					// calculate star amount
-					double fullStarCount = 5 * data["score"]?.Value<double>() ?? 0;
+					double fullStarCount = 5 * modData.voteData["score"]?.Value<double>() ?? 0;
 					double emptyStarCount = 5 - fullStarCount;
 
 					// concatinate star characters to string
@@ -490,8 +490,8 @@ namespace tModloaderDiscordBot.Modules
 						new string(Enumerable.Repeat('\u2606', (int)Math.Round(emptyStarCount)).ToArray()));
 
 					eb.AddField("Votes", s, true);
-					eb.AddField("Upvotes", data["votes_up"]?.Value<int>(), true);
-					eb.AddField("Downvotes", data["votes_down"]?.Value<int>(), true);
+					eb.AddField("Upvotes", modData.voteData["votes_up"]?.Value<int>(), true);
+					eb.AddField("Downvotes", modData.voteData["votes_down"]?.Value<int>(), true);
 				}
 
 				eb.AddField("Mod Side", modData.modside);
@@ -501,9 +501,11 @@ namespace tModloaderDiscordBot.Modules
 				eb.AddField("Time created", $"<t:{modData.timeCreated}:d>", true);
 
 				// if tags are present
-				if (modJData["tags"] is { } tags)
+				if (modJData["tags"].HasValues)
 				{
-					eb.AddField("Tags", string.Join(", ", tags?.Select(x => x["display_name"].Value<string>())));
+					var tags = modJData["tags"];
+					var tagNames = tags?.Select(x => x["display_name"].Value<string>());
+					eb.AddField("Tags", string.Join(", ", tagNames));
 				}
 
 				if (!string.IsNullOrEmpty(modData.homepage))

--- a/Modules/DefaultModule.cs
+++ b/Modules/DefaultModule.cs
@@ -334,8 +334,15 @@ namespace tModloaderDiscordBot.Modules
 		{
 			modName = modName.RemoveWhitespace();
 			string modJson = await ModService.DownloadSingleData(modName);
-			var modJData = JObject.Parse(modJson); // parse json string
-			
+			JObject modJData;
+			try {
+				modJData = JObject.Parse(modJson); // parse json string
+			}
+			catch {
+				await ReplyAsync(modJson);
+				return;
+			}
+
 			// parse json into object
 			var modData = new {
 				displayName = modJData["display_name"]?.Value<string>(),

--- a/Modules/DefaultModule.cs
+++ b/Modules/DefaultModule.cs
@@ -425,18 +425,15 @@ namespace tModloaderDiscordBot.Modules
 			try
 			{
 				modName = modName.RemoveWhitespace();
-				string modJson = await ModService.DownloadSingleData(modName);
-				JObject modJData;
-				try
-				{
-					modJData = JObject.Parse(modJson); // parse json string
-				}
-				catch
+				bool modFound = await ModService.TryCacheMod(modName);
+
+				if (!modFound)
 				{
 					await ReplyAsync($"A mod with the name \"{modName}\" was not found.");
-					Console.WriteLine($"{nameof(DefaultModule)}.{nameof(Mod)}: Error when parsing json. Server response was:\n{modJson}");
 					return;
 				}
+				
+				var modJData = JObject.Parse(await FileUtils.FileReadToEndAsync(new SemaphoreSlim(1, 1), ModService.ModPath(modName)));
 
 				// parse json into object
 				var modData = new

--- a/Modules/DefaultModule.cs
+++ b/Modules/DefaultModule.cs
@@ -469,7 +469,6 @@ namespace tModloaderDiscordBot.Modules
 					downloads = modJData["downloads_total"]?.Value<int>(),
 					views = modJData["views"]?.Value<int>(),
 					favorited = modJData["favorited"]?.Value<int>(),
-					playtime = modJData["playtime"]?.Value<string>(),
 					voteData = modJData["vote_data"]?.Value<JToken>(),
 					modside = modJData["modside"]?.Value<string>(),
 					tmodloaderVersion = modJData["tmodloader_version"]?.Value<string>(),
@@ -498,9 +497,6 @@ namespace tModloaderDiscordBot.Modules
 				eb.AddField("Downloads", $"{modData.downloads:n0}", true);
 				eb.AddField("Views", $"{modData.views:n0}", true);
 				eb.AddField("Favorites", $"{modData.favorited:n0}", true);
-
-				ulong playtime = ulong.Parse(modData.playtime ?? "0");
-				eb.AddField("Playtime", playtime / 3600_0000 + " hours");
 
 				// if vote data exists
 				if (modData.voteData is { } data)

--- a/Modules/DefaultModule.cs
+++ b/Modules/DefaultModule.cs
@@ -332,93 +332,109 @@ namespace tModloaderDiscordBot.Modules
 		[Priority(-99)]
 		public async Task Mod([Remainder] string modName)
 		{
-			modName = modName.RemoveWhitespace();
-			string modJson = await ModService.DownloadSingleData(modName);
-			JObject modJData;
-			try {
-				modJData = JObject.Parse(modJson); // parse json string
-			}
-			catch {
-				await ReplyAsync(modJson);
-				return;
-			}
-
-			// parse json into object
-			var modData = new {
-				displayName = modJData["display_name"]?.Value<string>(),
-				internalName = modJData["internal_name"]?.Value<string>(),
-				modID = modJData["mod_id"]?.Value<string>(),
-				version = modJData["version"]?.Value<string>(),
-				workshopIconURL = modJData["workshop_icon_url"]?.Value<string>(),
-				author = modJData["author"]?.Value<string>(),
-				authorID = modJData["author_id"]?.Value<string>(),
-				downloads = modJData["downloads_total"]?.Value<int>(),
-				views = modJData["views"]?.Value<int>(),
-				favorited = modJData["favorited"]?.Value<int>(),
-				playtime = modJData["playtime"]?.Value<string>(),
-				voteData = modJData["vote_data"]?.Value<JToken>(),
-				modside = modJData["modside"]?.Value<string>(),
-				tmodloaderVersion = modJData["tmodloader_version"]?.Value<string>(),
-				timeCreated = modJData["time_created"]?.Value<int>(),
-				timeUpdated = modJData["time_updated"]?.Value<int>(),
-				homepage = modJData["homepage"]?.Value<string>()
-			};
-			
-			// create embed
-			var eb = new EmbedBuilder()
-				.WithTitle($"Mod: {modData.displayName} ({modData.internalName}) {modData.version}")
-				.WithCurrentTimestamp()
-				.WithAuthor(new EmbedAuthorBuilder
-				{
-					IconUrl = Context.Message.Author.GetAvatarUrl(),
-					Name = $"Requested by {Context.Message.Author.FullName()}"
-				})
-				.WithUrl($"https://steamcommunity.com/sharedfiles/filedetails/?id={modData.modID}")
-				.WithThumbnailUrl(modData.workshopIconURL);
-
-			// add fields
-			eb.AddField("Author",
-				$"[{modData.author} ({modData.authorID})]" +
-				$"(https://steamcommunity.com/profiles/{modData.authorID}/)");
-
-			eb.AddField("Downloads", modData.downloads, true);
-			eb.AddField("Views", modData.views, true);
-			eb.AddField("Favorites", modData.favorited, true);
-
-			ulong playtime = ulong.Parse(modData.playtime ?? "0");
-			eb.AddField("Playtime", playtime / 3600_0000 + " hours");
-			
-			// if vote data exists
-			if (modData.voteData is { } data) {
-				// calculate star amount
-				double fullStarCount = 5 * data["score"]?.Value<double>() ?? 0;
-				double emptyStarCount = 5 - fullStarCount;
-				
-				// concatinate star characters to string
-				string s = string.Concat(
-					new string(Enumerable.Repeat('\u2605', (int)Math.Round(fullStarCount)).ToArray()),
-					new string(Enumerable.Repeat('\u2606', (int)Math.Round(emptyStarCount)).ToArray()));
-				
-				eb.AddField("Votes", s, true);
-				eb.AddField("Upvotes", data["votes_up"]?.Value<int>(), true);
-				eb.AddField("Downvotes", data["votes_down"]?.Value<int>(), true);
-			}
-			
-			eb.AddField("Mod Side", modData.modside);
-			eb.AddField("tModLoader Version", modData.tmodloaderVersion);
-
-			eb.AddField("Last updated", $"<t:{modData.timeUpdated}:d>", true);
-			eb.AddField("Time created", $"<t:{modData.timeCreated}:d>", true);
-
-			// if tags are present
-			if (modJData["tags"] is { } tags)
+			try
 			{
-				eb.AddField("Tags", string.Join(", ", tags?.Select(x => x["display_name"].Value<string>())));
-			}
+				modName = modName.RemoveWhitespace();
+				string modJson = await ModService.DownloadSingleData(modName);
+				JObject modJData;
+				try
+				{
+					modJData = JObject.Parse(modJson); // parse json string
+				}
+				catch
+				{
+					await ReplyAsync(modJson);
+					return;
+				}
 
-			eb.AddField("Homepage", modData.homepage);
-			
-			await ReplyAsync("", embed: eb.Build());
+				// parse json into object
+				var modData = new
+				{
+					displayName = modJData["display_name"]?.Value<string>(),
+					internalName = modJData["internal_name"]?.Value<string>(),
+					modID = modJData["mod_id"]?.Value<string>(),
+					version = modJData["version"]?.Value<string>(),
+					workshopIconURL = modJData["workshop_icon_url"]?.Value<string>(),
+					author = modJData["author"]?.Value<string>(),
+					authorID = modJData["author_id"]?.Value<string>(),
+					downloads = modJData["downloads_total"]?.Value<int>(),
+					views = modJData["views"]?.Value<int>(),
+					favorited = modJData["favorited"]?.Value<int>(),
+					playtime = modJData["playtime"]?.Value<string>(),
+					voteData = modJData["vote_data"]?.Value<JToken>(),
+					modside = modJData["modside"]?.Value<string>(),
+					tmodloaderVersion = modJData["tmodloader_version"]?.Value<string>(),
+					timeCreated = modJData["time_created"]?.Value<int>(),
+					timeUpdated = modJData["time_updated"]?.Value<int>(),
+					homepage = modJData["homepage"]?.Value<string>()
+				};
+
+				// create embed
+				var eb = new EmbedBuilder()
+					.WithTitle($"Mod: {modData.displayName} ({modData.internalName}) {modData.version}")
+					.WithCurrentTimestamp()
+					.WithAuthor(new EmbedAuthorBuilder
+					{
+						IconUrl = Context.Message.Author.GetAvatarUrl(),
+						Name = $"Requested by {Context.Message.Author.FullName()}"
+					})
+					.WithUrl($"https://steamcommunity.com/sharedfiles/filedetails/?id={modData.modID}")
+					.WithThumbnailUrl(modData.workshopIconURL);
+
+				// add fields
+				eb.AddField("Author",
+					$"[{modData.author} ({modData.authorID})]" +
+					$"(https://steamcommunity.com/profiles/{modData.authorID}/)");
+
+				eb.AddField("Downloads", modData.downloads, true);
+				eb.AddField("Views", modData.views, true);
+				eb.AddField("Favorites", modData.favorited, true);
+
+				ulong playtime = ulong.Parse(modData.playtime ?? "0");
+				eb.AddField("Playtime", playtime / 3600_0000 + " hours");
+
+				// if vote data exists
+				if (modData.voteData is { } data)
+				{
+					// calculate star amount
+					double fullStarCount = 5 * data["score"]?.Value<double>() ?? 0;
+					double emptyStarCount = 5 - fullStarCount;
+
+					// concatinate star characters to string
+					string s = string.Concat(
+						new string(Enumerable.Repeat('\u2605', (int)Math.Round(fullStarCount)).ToArray()),
+						new string(Enumerable.Repeat('\u2606', (int)Math.Round(emptyStarCount)).ToArray()));
+
+					eb.AddField("Votes", s, true);
+					eb.AddField("Upvotes", data["votes_up"]?.Value<int>(), true);
+					eb.AddField("Downvotes", data["votes_down"]?.Value<int>(), true);
+				}
+
+				eb.AddField("Mod Side", modData.modside);
+				eb.AddField("tModLoader Version", modData.tmodloaderVersion);
+
+				eb.AddField("Last updated", $"<t:{modData.timeUpdated}:d>", true);
+				eb.AddField("Time created", $"<t:{modData.timeCreated}:d>", true);
+
+				// if tags are present
+				if (modJData["tags"] is { } tags)
+				{
+					eb.AddField("Tags", string.Join(", ", tags?.Select(x => x["display_name"].Value<string>())));
+				}
+
+				if (!string.IsNullOrEmpty(modData.homepage))
+				{
+					eb.AddField("Homepage", modData.homepage);
+				}
+
+				var embed = eb.Build();
+
+				await ReplyAsync("", embed: embed);
+			}
+			catch 
+			{
+				await ReplyAsync("an error occured generating the embed");
+			}
 		}
 
 		// Helper method

--- a/Modules/DefaultModule.cs
+++ b/Modules/DefaultModule.cs
@@ -425,6 +425,7 @@ namespace tModloaderDiscordBot.Modules
 			try
 			{
 				modName = modName.RemoveWhitespace();
+				// TODO: Actually check cache before downloading a new cache.
 				bool modFound = await ModService.TryCacheMod(modName);
 
 				if (!modFound)

--- a/Modules/DefaultModule.cs
+++ b/Modules/DefaultModule.cs
@@ -56,7 +56,7 @@ namespace tModloaderDiscordBot.Modules
 		}
 
 		[Command("widget-legacy")]
-		[Alias("widgetimg-legacy", "widgetimage-legacy")]
+		[Alias("widgetimg-legacy", "widgetimage-legacy", "widget13")]
 		[Summary("Generates a widget image of specified mod")]
 		[Remarks("widget <mod>\nwidget examplemod")]
 		public async Task LegacyWidget([Remainder]string mod)
@@ -175,7 +175,7 @@ namespace tModloaderDiscordBot.Modules
 		}
 		
 		[Command("author-widget-legacy")]
-		[Alias("author-widgetimg-legacy", "author-widgetimage-legacy")]
+		[Alias("author-widgetimg-legacy", "author-widgetimage-legacy", "author-widget13")]
 		[Summary("Generates a widget image of the specified author")]
 		[Remarks("author-widget-legacy <steamid64>\nauthor-widget-legacy 76561198278789341")]
 		public async Task LegacyAuthorWidget([Remainder]string steamid)
@@ -336,7 +336,7 @@ namespace tModloaderDiscordBot.Modules
 		}
 
 		[Command("mod-legacy")]
-		[Alias("modinfo-legacy")]
+		[Alias("modinfo-legacy", "mod13")]
 		[Summary("Shows info about a mod")]
 		[Remarks("mod <internal modname> --OR-- mod <part of name>\nmod examplemod")]
 		[Priority(-99)]
@@ -535,7 +535,7 @@ namespace tModloaderDiscordBot.Modules
 		}
 
 		[Command("author-legacy")]
-		[Alias("authorinfo-legacy")]
+		[Alias("authorinfo-legacy", "author13")]
 		[Summary("Shows info about an author")]
 		[Remarks("author <steamid64 or steam name (not reliable)> \nauthor NotLe0n")]
 		[Priority(-99)]

--- a/Modules/DefaultModule.cs
+++ b/Modules/DefaultModule.cs
@@ -147,7 +147,7 @@ namespace tModloaderDiscordBot.Modules
 			}
 			catch
 			{
-				await ReplyAsync($"No mod with the name '{steamid}' found!");
+				await ReplyAsync($"No author with the name or ID '{steamid}' found!");
 				await msg.DeleteAsync();
 
 				return;
@@ -183,7 +183,7 @@ namespace tModloaderDiscordBot.Modules
 			}
 			catch
 			{
-				await ReplyAsync($"No mod with the name '{steamid}' found!");
+				await ReplyAsync($"No author with the name or ID '{steamid}' found!");
 				await msg.DeleteAsync();
 
 				return;
@@ -547,7 +547,7 @@ namespace tModloaderDiscordBot.Modules
 
 				var authorData = new
 				{
-					//steamID = authorJData["steam_id"]?.Value<string>(),
+					steamID = authorJData["steam_id"]?.Value<string>(),
 					steamName = authorJData["steam_name"]?.Value<string>(),
 					total = authorJData["total"]?.Value<int>(),
 					downloadsTotal = authorJData["downloads_total"]?.Value<int>(),
@@ -564,8 +564,8 @@ namespace tModloaderDiscordBot.Modules
 					{
 						IconUrl = Context.Message.Author.GetAvatarUrl(),
 						Name = $"Requested by {Context.Message.Author.FullName()}"
-					});
-					//.WithUrl($"https://steamcommunity.com/profiles/{authorData.steamID}/");
+					})
+					.WithUrl($"https://steamcommunity.com/profiles/{authorData.steamID}/");
 
 				eb.AddField("Total mod count", authorData.total ?? 0, true);
 				eb.AddField("Total downloads count", authorData.downloadsTotal ?? 0, true);
@@ -574,10 +574,10 @@ namespace tModloaderDiscordBot.Modules
 				string mods = string.Join(", ", authorData.mods
 					.Select(mod => mod?["display_name"]?.Value<string>()));
 				
-				eb.AddField("Mods", mods);
+				eb.AddField("Mods", authorData.mods.Any() ? mods : "No mods");
 
-				
-				if (authorData.maintainedMods.Count() != 0) {
+
+				if (authorData.maintainedMods.Any()) {
 					string maintainedMods = string.Join(", ", authorData.maintainedMods
 						.Select(mod => mod?["internal_name"]?.Value<string>()));
 

--- a/Modules/DefaultModule.cs
+++ b/Modules/DefaultModule.cs
@@ -55,6 +55,50 @@ namespace tModloaderDiscordBot.Modules
 				GetDeltaString(elapsed, clientLatency));
 		}
 
+		[Command("widget-legacy")]
+		[Alias("widgetimg-legacy", "widgetimage-legacy")]
+		[Summary("Generates a widget image of specified mod")]
+		[Remarks("widget <mod>\nwidget examplemod")]
+		public async Task LegacyWidget([Remainder]string mod)
+		{
+			mod = mod.RemoveWhitespace();
+			(bool result, string str) = await ShowSimilarMods(mod);
+
+			if (!result)
+			{
+				await ReplyAsync($"No mod with the name '{mod}' found!");
+				return;
+			}
+
+			string modFound = LegacyModService.Mods.FirstOrDefault(x => x.EqualsIgnoreCase(mod));
+
+			if (modFound == null)
+			{
+				await ReplyAsync($"No mod with the name '{mod}' found!");
+				return;
+			}
+
+			var msg = await ReplyAsync($"Generating widget for {modFound}...");
+
+			// need perfect string.
+
+			using var client = new System.Net.Http.HttpClient();
+			
+			byte[] response = await client.GetByteArrayAsync($"{LegacyModService.WidgetUrl}{modFound}");
+			if (response == null)
+			{
+				await ReplyAsync($"Unable to create the widget");
+				return;
+			}
+			
+			using (var stream = new MemoryStream(response))
+			{
+				await Context.Channel.SendFileAsync(stream, $"widget-{modFound}.png");
+			}
+
+			await msg.DeleteAsync();
+		}
+		
 		[Command("widget")]
 		[Alias("widgetimg", "widgetimage")]
 		[Summary("Generates a widget image of specified mod")]
@@ -62,30 +106,41 @@ namespace tModloaderDiscordBot.Modules
 		public async Task Widget([Remainder]string mod)
 		{
 			mod = mod.RemoveWhitespace();
-			var (result, str) = await ShowSimilarMods(mod);
+			(bool result, string str) = await ShowSimilarMods(mod);
 
-			if (result)
+			if (!result)
 			{
-				var modFound = LegacyModService.Mods.FirstOrDefault(x => x.EqualsIgnoreCase(mod));
-
-				if (modFound != null)
-				{
-					var msg = await ReplyAsync($"Generating widget for {modFound}...");
-
-					// need perfect string.
-
-					using (var client = new System.Net.Http.HttpClient())
-					{
-						var response = await client.GetByteArrayAsync($"{LegacyModService.WidgetUrl}{modFound}");
-						using (var stream = new MemoryStream(response))
-						{
-							await Context.Channel.SendFileAsync(stream, $"widget-{modFound}.png");
-						}
-					}
-					await msg.DeleteAsync();
-				}
+				await ReplyAsync($"No mod with the name '{mod}' found!");
+				return;
 			}
 
+			string modFound = LegacyModService.Mods.FirstOrDefault(x => x.EqualsIgnoreCase(mod));
+
+			if (modFound == null)
+			{
+				await ReplyAsync($"No mod with the name '{mod}' found!");
+				return;
+			}
+
+			var msg = await ReplyAsync($"Generating widget for {modFound}...");
+
+			// need perfect string.
+
+			using var client = new System.Net.Http.HttpClient();
+			
+			byte[] response = await client.GetByteArrayAsync($"{ModService.WidgetUrl}{modFound}");
+			if (response == null)
+			{
+				await ReplyAsync($"Unable to create the widget");
+				return;
+			}
+			
+			using (var stream = new MemoryStream(response))
+			{
+				await Context.Channel.SendFileAsync(stream, $"widget-{modFound}.png");
+			}
+
+			await msg.DeleteAsync();
 		}
 
 		[Command("wikis")]

--- a/Modules/DefaultModule.cs
+++ b/Modules/DefaultModule.cs
@@ -162,7 +162,7 @@ namespace tModloaderDiscordBot.Modules
 		[Command("author-widget-legacy")]
 		[Alias("author-widgetimg-legacy", "author-widgetimage-legacy", "author-widget13")]
 		[Summary("Generates a widget image of the specified author")]
-		[Remarks("author-widget-legacy <steamid64>\nauthor-widget-legacy 76561198278789341")]
+		[Remarks("author-widget13 <steamid64>\nauthor-widget13 76561198278789341")]
 		public async Task LegacyAuthorWidget([Remainder]string steamid)
 		{
 			steamid = steamid.RemoveWhitespace();
@@ -226,24 +226,6 @@ namespace tModloaderDiscordBot.Modules
 			searchTerm = searchTerm.Trim();
 			var encoded = WebUtility.UrlEncode(searchTerm);
 			await ReplyAsync($"Microsoft docs for {searchTerm}: <https://docs.microsoft.com/en-us/search/?scope=.NET&terms={encoded}>");
-		}
-
-		[Command("ranksbysteamid")]
-		[Alias("ranksbyauthor", "listmods")]
-		[Summary("Generates a link for the ranksbysteamid of the steamid64 provided.")]
-		[Remarks("ranksbysteamid <steam64id>\ranksbysteamid 76561198422040054")]
-		public async Task RanksBySteamID([Remainder]string steamid64)
-		{
-			steamid64 = steamid64.Trim();
-			if (steamid64.Length == 17 && steamid64.All(c => c >= '0' && c <= '9'))
-			{
-				string encoded = WebUtility.UrlEncode(steamid64);
-				await ReplyAsync($"tModLoader ranks by steamid results for {steamid64}: <http://javid.ddns.net/tModLoader/tools/ranksbysteamid.php?steamid64={encoded}>");
-			}
-			else
-				await ReplyAsync($"\"{steamid64}\" is not a valid steamid64");
-
-			// Todo: allow users to register their username under a steamid64 and allow username to be used here.
 		}
 
 		// Current classes documented on the Wiki
@@ -436,7 +418,7 @@ namespace tModloaderDiscordBot.Modules
 		[Command("mod")]
 		[Alias("modinfo")]
 		[Summary("Shows info about a mod")]
-		[Remarks("mod <internal modname or mod id> \nmod examplemod")]
+		[Remarks("mod <internal modname or mod id> \n`mod 2831018225` --OR-- `mod examplemod`")]
 		[Priority(-99)]
 		public async Task Mod([Remainder] string modName)
 		{
@@ -545,7 +527,7 @@ namespace tModloaderDiscordBot.Modules
 		[Command("author-legacy")]
 		[Alias("authorinfo-legacy", "author13")]
 		[Summary("Shows info about an author")]
-		[Remarks("author13 <steamid64 or steam name (not reliable)> \nauthor13 NotLe0n")]
+		[Remarks("author13 <steamid64 or steam name (not reliable)>\n`author13 76561198278789341` --OR-- `author13 NotLe0n`")]
 		[Priority(-99)]
 		public async Task LegacyAuthor([Remainder] string steamID)
 		{
@@ -616,7 +598,7 @@ namespace tModloaderDiscordBot.Modules
 		[Command("author")]
 		[Alias("authorinfo")]
 		[Summary("Shows info about an author")]
-		[Remarks("author <steamid64 or steam name (not reliable)> \nauthor NotLe0n")]
+		[Remarks("author <steamid64 or steam name (not reliable)> \n`author 76561198278789341` --OR-- `author NotLe0n`")]
 		[Priority(-99)]
 		public async Task Author([Remainder] string steamID)
 		{

--- a/Modules/DefaultModule.cs
+++ b/Modules/DefaultModule.cs
@@ -440,7 +440,7 @@ namespace tModloaderDiscordBot.Modules
 				}
 				catch
 				{
-					await ReplyAsync("an error occured when parsing JSON");
+					await ReplyAsync($"A mod with the name \"{modName}\" was not found.");
 					Console.WriteLine($"{nameof(DefaultModule)}.{nameof(Mod)}: Error when parsing json. Server response was:\n{modJson}");
 					return;
 				}
@@ -552,7 +552,7 @@ namespace tModloaderDiscordBot.Modules
 				}
 				catch
 				{
-					await ReplyAsync("an error occured when parsing JSON");
+					await ReplyAsync($"An author with the ID \"{steamID}\" was not found.");
 					Console.WriteLine($"{nameof(DefaultModule)}.{nameof(LegacyAuthor)}: Error when parsing json. Server response was:\n{authorJson}");
 					return;
 				}
@@ -626,9 +626,9 @@ namespace tModloaderDiscordBot.Modules
 				{
 					authorJData = JObject.Parse(authorJson);
 				}
-				catch (Exception e)
+				catch
 				{
-					await ReplyAsync("an error occured when parsing JSON");
+					await ReplyAsync($"An author with the ID \"{steamID}\" was not found.");
 					Console.WriteLine($"{nameof(DefaultModule)}.{nameof(Author)}: Error when parsing json. Server response was:\n{authorJson}");
 					return;
 				}

--- a/Program.cs
+++ b/Program.cs
@@ -124,6 +124,7 @@ namespace tModloaderDiscordBot
 
 			await _services.GetRequiredService<GuildConfigService>().SetupAsync();
 			await _services.GetRequiredService<SiteStatusService>().UpdateAsync();
+			await _services.GetRequiredService<ModService>().Initialize().Maintain();
 			await _services.GetRequiredService<LegacyModService>().Initialize().Maintain();
 			//await _reactionRoleService.Maintain(_client);
 

--- a/Program.cs
+++ b/Program.cs
@@ -45,6 +45,7 @@ namespace tModloaderDiscordBot
 						.AddSingleton<SiteStatusService>()
 						.AddSingleton<GuildTagService>()
 						.AddSingleton<PermissionService>()
+						.AddSingleton<LegacyModService>()
 						.AddSingleton<ModService>()
 						.BuildServiceProvider();
 			}
@@ -122,11 +123,11 @@ namespace tModloaderDiscordBot
 
 			await _services.GetRequiredService<GuildConfigService>().SetupAsync();
 			await _services.GetRequiredService<SiteStatusService>().UpdateAsync();
-			await _services.GetRequiredService<ModService>().Initialize().Maintain();
+			await _services.GetRequiredService<LegacyModService>().Initialize().Maintain();
 			//await _reactionRoleService.Maintain(_client);
 
 			await _services.GetRequiredService<LoggingService>().Log(new LogMessage(LogSeverity.Info, "ClientReady", "Done."));
-			await _client.SetGameAsync("tModLoader " + ModService.tMLVersion);
+			await _client.SetGameAsync("tModLoader " + LegacyModService.tMLVersion);
 			await ClientLatencyUpdated(_client.Latency, _client.Latency);
 #if !TESTBOT
 			var botChannel = (ISocketMessageChannel)await _client.GetChannelAsync(242228770855976960);

--- a/Program.cs
+++ b/Program.cs
@@ -47,6 +47,7 @@ namespace tModloaderDiscordBot
 						.AddSingleton<PermissionService>()
 						.AddSingleton<LegacyModService>()
 						.AddSingleton<ModService>()
+						.AddSingleton<AuthorService>()
 						.BuildServiceProvider();
 			}
 

--- a/Services/AuthorService.cs
+++ b/Services/AuthorService.cs
@@ -10,13 +10,25 @@ namespace tModloaderDiscordBot.Services
 		{
 		}
 		
-		internal const string ModInfoUrl = "https://tmlapis.tomat.dev/1.4/author/";
+		internal const string AuthorInfoUrl = "https://tmlapis.tomat.dev/1.4/author/";
+		internal const string LegacyAuthorInfoUrl = "https://tmlapis.tomat.dev/1.3/author/";
+
 		
 		public async Task<string> DownloadSingleData(string name)
 		{
 			using (var client = new System.Net.Http.HttpClient())
 			{
-				var response = await client.GetAsync(ModInfoUrl + name);
+				var response = await client.GetAsync(AuthorInfoUrl + name);
+				string postResponse = await response.Content.ReadAsStringAsync();
+				return postResponse;
+			}
+		}
+		
+		public async Task<string> DownloadSingleLegacyData(string name)
+		{
+			using (var client = new System.Net.Http.HttpClient())
+			{
+				var response = await client.GetAsync(LegacyAuthorInfoUrl + name);
 				string postResponse = await response.Content.ReadAsStringAsync();
 				return postResponse;
 			}

--- a/Services/AuthorService.cs
+++ b/Services/AuthorService.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Net.Http;
+using System.Threading.Tasks;
+
+namespace tModloaderDiscordBot.Services
+{
+	public class AuthorService : BaseService
+	{
+		public AuthorService(IServiceProvider services) : base(services)
+		{
+		}
+		
+		internal const string ModInfoUrl = "https://tmlapis.tomat.dev/1.4/author/";
+		
+		public async Task<string> DownloadSingleData(string name)
+		{
+			using (var client = new System.Net.Http.HttpClient())
+			{
+				var response = await client.GetAsync(ModInfoUrl + name);
+				string postResponse = await response.Content.ReadAsStringAsync();
+				return postResponse;
+			}
+		}
+	}
+}

--- a/Services/AuthorService.cs
+++ b/Services/AuthorService.cs
@@ -10,28 +10,29 @@ namespace tModloaderDiscordBot.Services
 		{
 		}
 		
-		internal const string AuthorInfoUrl = "https://tmlapis.tomat.dev/1.4/author/";
-		internal const string LegacyAuthorInfoUrl = "https://tmlapis.tomat.dev/1.3/author/";
+		private const string AuthorInfoUrl = "https://tmlapis.tomat.dev/1.4/author/";
+		private const string LegacyAuthorInfoUrl = "https://tmlapis.tomat.dev/1.3/author/";
+		internal const string WidgetUrl = "https://tml-readme-card.repl.co/?steamid64=";
+		internal const string LegacyWidgetUrl = "https://tml-readme-card.repl.co/?v=1.3&steamid64=";
 
 		
+		private static async Task<string> GetString(string url)
+		{
+			using var client = new System.Net.Http.HttpClient();
+			
+			var response = await client.GetAsync(url);
+			string postResponse = await response.Content.ReadAsStringAsync();
+			return postResponse;
+		}
+
 		public async Task<string> DownloadSingleData(string name)
 		{
-			using (var client = new System.Net.Http.HttpClient())
-			{
-				var response = await client.GetAsync(AuthorInfoUrl + name);
-				string postResponse = await response.Content.ReadAsStringAsync();
-				return postResponse;
-			}
+			return await GetString(AuthorInfoUrl + name);
 		}
 		
 		public async Task<string> DownloadSingleLegacyData(string name)
 		{
-			using (var client = new System.Net.Http.HttpClient())
-			{
-				var response = await client.GetAsync(LegacyAuthorInfoUrl + name);
-				string postResponse = await response.Content.ReadAsStringAsync();
-				return postResponse;
-			}
+			return await GetString(LegacyAuthorInfoUrl + name);
 		}
 	}
 }

--- a/Services/BanAppealChannelService.cs
+++ b/Services/BanAppealChannelService.cs
@@ -16,7 +16,7 @@ namespace tModloaderDiscordBot.Services
 		private bool _isSetup = false;
 
 #if TESTBOT
-		private const ulong banAppealChannelId = 816493360722083851;
+		private const ulong banAppealChannelId = 1041803889105702923;
 #else
 		private const ulong banAppealChannelId = 331867286312845313;
 #endif

--- a/Services/BanAppealChannelService.cs
+++ b/Services/BanAppealChannelService.cs
@@ -16,7 +16,7 @@ namespace tModloaderDiscordBot.Services
 		private bool _isSetup = false;
 
 #if TESTBOT
-		private const ulong banAppealChannelId = 1041803889105702923;
+		private const ulong banAppealChannelId = 816493360722083851;
 #else
 		private const ulong banAppealChannelId = 331867286312845313;
 #endif

--- a/Services/LegacyModService.cs
+++ b/Services/LegacyModService.cs
@@ -184,7 +184,7 @@ namespace tModloaderDiscordBot.Services
 
 		private async Task Log(string msg)
 		{
-			await _loggingService.Log(new LogMessage(LogSeverity.Info, "ModService", msg));
+			await _loggingService.Log(new LogMessage(LogSeverity.Info, "ModServ13", msg));
 		}
 	}
 }

--- a/Services/LegacyModService.cs
+++ b/Services/LegacyModService.cs
@@ -18,7 +18,7 @@ namespace tModloaderDiscordBot.Services
 	{
 		internal const string QueryDownloadUrl = "http://javid.ddns.net/tModLoader/tools/querymoddownloadurl.php?modname=";
 		internal const string QueryHomepageUrl = "http://javid.ddns.net/tModLoader/tools/querymodhomepage.php?modname=";
-		internal const string WidgetUrl = "https://bettermodwidget.javidpack.repl.co/?mod=";
+		internal const string WidgetUrl = "https://tml-readme-card.repl.co/?v=1.3&modname=";
 		internal const string XmlUrl = "http://javid.ddns.net/tModLoader/listmods.php";
 		internal const string ModInfoUrl = "http://javid.ddns.net/tModLoader/tools/modinfo.php";
 		internal const string HomepageUrl = "http://javid.ddns.net/tModLoader/moddescription.php";

--- a/Services/LegacyModService.cs
+++ b/Services/LegacyModService.cs
@@ -1,0 +1,182 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.IO.Compression;
+using System.Linq;
+using System.Net;
+using System.Threading;
+using System.Threading.Tasks;
+using Discord;
+using Discord.WebSocket;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using tModloaderDiscordBot.Utils;
+
+namespace tModloaderDiscordBot.Services
+{
+	public class LegacyModService : BaseService
+	{
+		internal const string QueryDownloadUrl = "http://javid.ddns.net/tModLoader/tools/querymoddownloadurl.php?modname=";
+		internal const string QueryHomepageUrl = "http://javid.ddns.net/tModLoader/tools/querymodhomepage.php?modname=";
+		internal const string WidgetUrl = "https://bettermodwidget.javidpack.repl.co/?mod=";
+		internal const string XmlUrl = "http://javid.ddns.net/tModLoader/listmods.php";
+		internal const string ModInfoUrl = "http://javid.ddns.net/tModLoader/tools/modinfo.php";
+		internal const string HomepageUrl = "http://javid.ddns.net/tModLoader/moddescription.php";
+		internal const string PopularUrl = "http://javid.ddns.net/tModLoader/tools/populartop10.php";
+		internal const string HotUrl = "http://javid.ddns.net/tModLoader/tools/hottop10.php";
+		internal const string NewestReleaseUrl = "https://api.github.com/repos/tModLoader/tModLoader/releases/latest";
+
+		private static string ModDir => "mods";
+		internal static string tMLVersion;
+
+		public static string ModPath(string modname) =>
+			Path.Combine(ModDir, $"{modname}.json");
+
+		public static IEnumerable<string> Mods =>
+			Directory.GetFiles(ModDir, "*.json")
+				.Select(x => Path.GetFileNameWithoutExtension(x).RemoveWhitespace());
+
+		private static SemaphoreSlim _semaphore;
+		//private static Timer _updateTimer;
+
+		public LegacyModService(IServiceProvider services) : base(services)
+		{
+		}
+
+		public LegacyModService Initialize()
+		{
+			//using var client = new WebClient();
+			//The Github api expects at least more than 5 letters here, change it to whatever you want
+			//client.Headers.Add("user-agent", "Discord.Net");
+			
+			/* This not working anymore with 1.4 alphas making releases.
+			tMLVersion = $"tModLoader {JObject.Parse(client.DownloadString(NewestReleaseUrl)).GetValue("tag_name")}";
+			*/
+			tMLVersion = $"tModLoader v0.11.8.8";
+			_semaphore = new SemaphoreSlim(1, 1);
+
+			//if (_updateTimer == null)
+			//{
+			//	_updateTimer = new Timer(async (e) =>
+			//	{
+			//		await Log("Running maintenance from 6 hour timer");
+			//		await Maintain(_client);
+			//	},
+			//	null, TimeSpan.FromHours(6), TimeSpan.FromHours(6));
+			//}
+			return this;
+		}
+
+		public async Task Maintain()
+		{
+			await Log("Starting maintenance");
+			// Create dirs
+			Directory.CreateDirectory(ModDir);
+
+			var path = Path.Combine(ModDir, "date.txt");
+			var dateDiff = TimeSpan.MinValue;
+
+			// Data.txt present, read
+			if (File.Exists(path))
+			{
+				var savedBinary = await FileUtils.FileReadToEndAsync(_semaphore, path);
+				var parsedBinary = long.Parse(savedBinary);
+				var savedBinaryDate = BotUtils.DateTimeFromUnixTimestampSeconds(parsedBinary);
+				dateDiff = BotUtils.DateTimeFromUnixTimestampSeconds(BotUtils.GetCurrentUnixTimestampSeconds()) - savedBinaryDate;
+				await Log($"Read date difference for mod cache update: {dateDiff}");
+			}
+
+			// Needs to maintain data
+			if (dateDiff == TimeSpan.MinValue
+				|| dateDiff.TotalHours > 5.99d)
+			{
+				await Log($"Maintenance determined: over 6 hours. Updating...");
+				var data = await DownloadData();
+				JObject jsonObject = JObject.Parse(data);
+				JArray modlist;
+				string modlist_compressed = (string)jsonObject["modlist_compressed"];
+				if (modlist_compressed != null)
+				{
+					byte[] compressedData = Convert.FromBase64String(modlist_compressed);
+					using (GZipStream zip = new GZipStream(new MemoryStream(compressedData), CompressionMode.Decompress))
+					using (var reader = new StreamReader(zip))
+						modlist = JArray.Parse(reader.ReadToEnd());
+				}
+				else
+				{
+					// Fallback if needed.
+					modlist = (JArray)jsonObject["modlist"];
+				}
+				foreach (var jtoken in modlist)
+				{
+					var name = jtoken.SelectToken("name").ToObject<string>().RemoveWhitespace();
+					if(jtoken["download"] == null)
+						jtoken["download"] = $"http://javid.ddns.net/tModLoader/download.php?Down=mods/{name}.tmod";
+					if (jtoken["modside"] == null)
+						jtoken["modside"] = "Both";
+					var jsonPath = Path.Combine(ModDir, $"{name}.json");
+					await FileUtils.FileWriteAsync(_semaphore, jsonPath, jtoken.ToString(Formatting.Indented));
+				}
+
+				await FileUtils.FileWriteAsync(_semaphore, path, BotUtils.GetCurrentUnixTimestampSeconds().ToString());
+				await Log($"File write successful");
+			}
+		}
+
+		public async Task<bool> TryCacheMod(string name)
+		{
+			await Log($"Attempting to update cache for mod {name}");
+			var data = await DownloadSingleData(name);
+			if (data.StartsWith("Failed:"))
+			{
+				await Log($"Cache update for mod {name} failed");
+				return false;
+			}
+
+			var mod = JObject.Parse(data);
+			await FileUtils.FileWriteAsync(_semaphore, Path.Combine(ModDir, $"{mod.SelectToken("name").ToObject<string>()}.json"), mod.ToString(Formatting.Indented));
+			await Log($"Cache update for mod {name} succeeded");
+			return true;
+		}
+
+		private async Task<string> DownloadData()
+		{
+			await Log($"Requesting DownloadData. tMod version: {tMLVersion}");
+			using (var client = new System.Net.Http.HttpClient())
+			{
+				//var version = await GetTMLVersion();
+
+				var values = new Dictionary<string, string>
+				{
+					{ "modloaderversion", $"tModLoader {tMLVersion}" },
+					{ "platform", "w"}
+				};
+				var content = new System.Net.Http.FormUrlEncodedContent(values);
+
+				await Log("Sending post request");
+				var response = await client.PostAsync(XmlUrl, content);
+
+				await Log("Reading post request");
+				var postResponse = await response.Content.ReadAsStringAsync();
+
+				await Log("Done downloading data");
+				return postResponse;
+			}
+		}
+
+		private async Task<string> DownloadSingleData(string name)
+		{
+			using (var client = new System.Net.Http.HttpClient())
+			{
+				var response = await client.GetAsync(ModInfoUrl + $"?modname={name}");
+				var postResponse = await response.Content.ReadAsStringAsync();
+				return postResponse;
+			}
+		}
+
+		private async Task Log(string msg)
+		{
+			await _loggingService.Log(new LogMessage(LogSeverity.Info, "ModService", msg));
+		}
+	}
+}

--- a/Services/ModService.cs
+++ b/Services/ModService.cs
@@ -1,182 +1,25 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.IO;
-using System.IO.Compression;
-using System.Linq;
-using System.Net;
-using System.Threading;
+using System.Net.Http;
 using System.Threading.Tasks;
-using Discord;
-using Discord.WebSocket;
-using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
-using tModloaderDiscordBot.Utils;
 
 namespace tModloaderDiscordBot.Services
 {
 	public class ModService : BaseService
 	{
-		internal const string QueryDownloadUrl = "http://javid.ddns.net/tModLoader/tools/querymoddownloadurl.php?modname=";
-		internal const string QueryHomepageUrl = "http://javid.ddns.net/tModLoader/tools/querymodhomepage.php?modname=";
-		internal const string WidgetUrl = "https://bettermodwidget.javidpack.repl.co/?mod=";
-		internal const string XmlUrl = "http://javid.ddns.net/tModLoader/listmods.php";
-		internal const string ModInfoUrl = "http://javid.ddns.net/tModLoader/tools/modinfo.php";
-		internal const string HomepageUrl = "http://javid.ddns.net/tModLoader/moddescription.php";
-		internal const string PopularUrl = "http://javid.ddns.net/tModLoader/tools/populartop10.php";
-		internal const string HotUrl = "http://javid.ddns.net/tModLoader/tools/hottop10.php";
-		internal const string NewestReleaseUrl = "https://api.github.com/repos/tModLoader/tModLoader/releases/latest";
-
-		private static string ModDir => "mods";
-		internal static string tMLVersion;
-
-		public static string ModPath(string modname) =>
-			Path.Combine(ModDir, $"{modname}.json");
-
-		public static IEnumerable<string> Mods =>
-			Directory.GetFiles(ModDir, "*.json")
-				.Select(x => Path.GetFileNameWithoutExtension(x).RemoveWhitespace());
-
-		private static SemaphoreSlim _semaphore;
-		//private static Timer _updateTimer;
-
 		public ModService(IServiceProvider services) : base(services)
 		{
 		}
-
-		public ModService Initialize()
-		{
-			//using var client = new WebClient();
-			//The Github api expects at least more than 5 letters here, change it to whatever you want
-			//client.Headers.Add("user-agent", "Discord.Net");
-			
-			/* This not working anymore with 1.4 alphas making releases.
-			tMLVersion = $"tModLoader {JObject.Parse(client.DownloadString(NewestReleaseUrl)).GetValue("tag_name")}";
-			*/
-			tMLVersion = $"tModLoader v0.11.8.8";
-			_semaphore = new SemaphoreSlim(1, 1);
-
-			//if (_updateTimer == null)
-			//{
-			//	_updateTimer = new Timer(async (e) =>
-			//	{
-			//		await Log("Running maintenance from 6 hour timer");
-			//		await Maintain(_client);
-			//	},
-			//	null, TimeSpan.FromHours(6), TimeSpan.FromHours(6));
-			//}
-			return this;
-		}
-
-		public async Task Maintain()
-		{
-			await Log("Starting maintenance");
-			// Create dirs
-			Directory.CreateDirectory(ModDir);
-
-			var path = Path.Combine(ModDir, "date.txt");
-			var dateDiff = TimeSpan.MinValue;
-
-			// Data.txt present, read
-			if (File.Exists(path))
-			{
-				var savedBinary = await FileUtils.FileReadToEndAsync(_semaphore, path);
-				var parsedBinary = long.Parse(savedBinary);
-				var savedBinaryDate = BotUtils.DateTimeFromUnixTimestampSeconds(parsedBinary);
-				dateDiff = BotUtils.DateTimeFromUnixTimestampSeconds(BotUtils.GetCurrentUnixTimestampSeconds()) - savedBinaryDate;
-				await Log($"Read date difference for mod cache update: {dateDiff}");
-			}
-
-			// Needs to maintain data
-			if (dateDiff == TimeSpan.MinValue
-				|| dateDiff.TotalHours > 5.99d)
-			{
-				await Log($"Maintenance determined: over 6 hours. Updating...");
-				var data = await DownloadData();
-				JObject jsonObject = JObject.Parse(data);
-				JArray modlist;
-				string modlist_compressed = (string)jsonObject["modlist_compressed"];
-				if (modlist_compressed != null)
-				{
-					byte[] compressedData = Convert.FromBase64String(modlist_compressed);
-					using (GZipStream zip = new GZipStream(new MemoryStream(compressedData), CompressionMode.Decompress))
-					using (var reader = new StreamReader(zip))
-						modlist = JArray.Parse(reader.ReadToEnd());
-				}
-				else
-				{
-					// Fallback if needed.
-					modlist = (JArray)jsonObject["modlist"];
-				}
-				foreach (var jtoken in modlist)
-				{
-					var name = jtoken.SelectToken("name").ToObject<string>().RemoveWhitespace();
-					if(jtoken["download"] == null)
-						jtoken["download"] = $"http://javid.ddns.net/tModLoader/download.php?Down=mods/{name}.tmod";
-					if (jtoken["modside"] == null)
-						jtoken["modside"] = "Both";
-					var jsonPath = Path.Combine(ModDir, $"{name}.json");
-					await FileUtils.FileWriteAsync(_semaphore, jsonPath, jtoken.ToString(Formatting.Indented));
-				}
-
-				await FileUtils.FileWriteAsync(_semaphore, path, BotUtils.GetCurrentUnixTimestampSeconds().ToString());
-				await Log($"File write successful");
-			}
-		}
-
-		public async Task<bool> TryCacheMod(string name)
-		{
-			await Log($"Attempting to update cache for mod {name}");
-			var data = await DownloadSingleData(name);
-			if (data.StartsWith("Failed:"))
-			{
-				await Log($"Cache update for mod {name} failed");
-				return false;
-			}
-
-			var mod = JObject.Parse(data);
-			await FileUtils.FileWriteAsync(_semaphore, Path.Combine(ModDir, $"{mod.SelectToken("name").ToObject<string>()}.json"), mod.ToString(Formatting.Indented));
-			await Log($"Cache update for mod {name} succeeded");
-			return true;
-		}
-
-		private async Task<string> DownloadData()
-		{
-			await Log($"Requesting DownloadData. tMod version: {tMLVersion}");
-			using (var client = new System.Net.Http.HttpClient())
-			{
-				//var version = await GetTMLVersion();
-
-				var values = new Dictionary<string, string>
-				{
-					{ "modloaderversion", $"tModLoader {tMLVersion}" },
-					{ "platform", "w"}
-				};
-				var content = new System.Net.Http.FormUrlEncodedContent(values);
-
-				await Log("Sending post request");
-				var response = await client.PostAsync(XmlUrl, content);
-
-				await Log("Reading post request");
-				var postResponse = await response.Content.ReadAsStringAsync();
-
-				await Log("Done downloading data");
-				return postResponse;
-			}
-		}
-
-		private async Task<string> DownloadSingleData(string name)
+		
+		internal const string ModInfoUrl = "https://tmlapis.tomat.dev/1.4/mod/";
+		
+		public async Task<string> DownloadSingleData(string name)
 		{
 			using (var client = new System.Net.Http.HttpClient())
 			{
-				var response = await client.GetAsync(ModInfoUrl + $"?modname={name}");
-				var postResponse = await response.Content.ReadAsStringAsync();
+				var response = await client.GetAsync(ModInfoUrl + name);
+				string postResponse = await response.Content.ReadAsStringAsync();
 				return postResponse;
 			}
-		}
-
-		private async Task Log(string msg)
-		{
-			await _loggingService.Log(new LogMessage(LogSeverity.Info, "ModService", msg));
 		}
 	}
 }

--- a/Services/ModService.cs
+++ b/Services/ModService.cs
@@ -1,7 +1,13 @@
 ﻿using System;
+using System.IO;
+using System.IO.Compression;
 using System.Net.Http;
+using System.Threading;
 using System.Threading.Tasks;
 using Discord;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using tModloaderDiscordBot.Utils;
 
 namespace tModloaderDiscordBot.Services
 {
@@ -13,8 +19,101 @@ namespace tModloaderDiscordBot.Services
 		
 		internal const string WidgetUrl = "https://tml-readme-card.repl.co/?v=1.4&modname=";
 		private const string ModInfoUrl = "https://tmlapis.tomat.dev/1.4/mod/";
+		private const string ModListUrl = "https://tmlapis.tomat.dev/1.4/list/";
 		
-		public async Task<string> DownloadSingleData(string name)
+		private static string ModDir => "mods/1.4";
+		private static Timer _updateTimer;
+		private static SemaphoreSlim _semaphore;
+		
+		public static string ModPath(string modname) =>
+			Path.Combine(ModDir, $"{modname}.json");
+		
+		public ModService Initialize()
+		{
+			_semaphore = new SemaphoreSlim(1, 1);
+			_updateTimer ??= new Timer(UpdateMods, null, TimeSpan.FromHours(6), TimeSpan.FromHours(6));
+			return this;
+		}
+		
+		private async void UpdateMods(object state)
+		{
+			await Log("Running 1.4 maintenance from 6 hour timer");
+			await Maintain();
+		}
+		
+		public async Task Maintain()
+		{
+			await Log("Starting 1.4 maintenance");
+			// Create dirs
+			Directory.CreateDirectory(ModDir);
+
+			string path = Path.Combine(ModDir, "date.txt");
+			var dateDiff = TimeSpan.MinValue;
+
+			// Data.txt present, read
+			if (File.Exists(path))
+			{
+				string savedBinary = await FileUtils.FileReadToEndAsync(_semaphore, path);
+				long parsedBinary = long.Parse(savedBinary);
+				var savedBinaryDate = BotUtils.DateTimeFromUnixTimestampSeconds(parsedBinary);
+				dateDiff = BotUtils.DateTimeFromUnixTimestampSeconds(BotUtils.GetCurrentUnixTimestampSeconds()) - savedBinaryDate;
+				await Log($"Read date difference for 1.4 mod cache update: {dateDiff}");
+			}
+
+			// Needs to maintain data
+			if (dateDiff == TimeSpan.MinValue || dateDiff.TotalHours > 5.99d)
+			{
+				await Log($"Maintenance determined: over 6 hours. Updating...");
+				
+				string data = await DownloadModListData();
+				var modList = JArray.Parse(data);
+				
+				foreach (var jToken in modList)
+				{
+					string name = jToken["internal_name"]?.ToObject<string>().RemoveWhitespace();
+					string jsonPath = Path.Combine(ModDir, $"{name}.json");
+					await FileUtils.FileWriteAsync(_semaphore, jsonPath, jToken.ToString(Formatting.Indented));
+				}
+
+				await FileUtils.FileWriteAsync(_semaphore, path, BotUtils.GetCurrentUnixTimestampSeconds().ToString());
+				await Log($"File write successful");
+			}
+		}
+
+		public async Task<bool> TryCacheMod(string name)
+		{
+			await Log($"Attempting to update cache for mod {name}");
+			
+			string data = await DownloadSingleData(name);
+			if (data is null)
+			{
+				await Log($"Cache update for mod {name} failed");
+				return false;
+			}
+
+			var mod = JObject.Parse(data);
+			await FileUtils.FileWriteAsync(_semaphore, Path.Combine(ModDir, $"{mod["internal_name"]?.ToObject<string>()}.json"), mod.ToString(Formatting.Indented));
+			await Log($"Cache update for mod {name} succeeded");
+			return true;
+		}
+		
+		private async Task<string> DownloadModListData()
+		{
+			using var client = new HttpClient();
+			var response = await client.GetAsync(ModListUrl);
+
+			if (!response.IsSuccessStatusCode)
+			{
+				await _loggingService.Log(new LogMessage(LogSeverity.Error, nameof(ModService),
+					$"'{ModInfoUrl}' responded with code {response.StatusCode}"));
+				return null;
+			}
+				
+			string postResponse = await response.Content.ReadAsStringAsync();
+			return postResponse;
+		}
+		
+		private async Task<string> DownloadSingleData(string name)
 		{
 			using var client = new HttpClient();
 			var response = await client.GetAsync(ModInfoUrl + name);
@@ -28,6 +127,11 @@ namespace tModloaderDiscordBot.Services
 				
 			string postResponse = await response.Content.ReadAsStringAsync();
 			return postResponse;
+		}
+		
+		private async Task Log(string msg)
+		{
+			await _loggingService.Log(new LogMessage(LogSeverity.Info, "ModService", msg));
 		}
 	}
 }

--- a/Services/ModService.cs
+++ b/Services/ModService.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Net.Http;
 using System.Threading.Tasks;
+using Discord;
 
 namespace tModloaderDiscordBot.Services
 {
@@ -10,16 +11,22 @@ namespace tModloaderDiscordBot.Services
 		{
 		}
 		
-		internal const string ModInfoUrl = "https://tmlapis.tomat.dev/1.4/mod/";
+		private const string ModInfoUrl = "https://tmlapis.tomat.dev/1.4/mod/";
 		
 		public async Task<string> DownloadSingleData(string name)
 		{
-			using (var client = new System.Net.Http.HttpClient())
+			using var client = new HttpClient();
+			var response = await client.GetAsync(ModInfoUrl + name);
+
+			if (!response.IsSuccessStatusCode)
 			{
-				var response = await client.GetAsync(ModInfoUrl + name);
-				string postResponse = await response.Content.ReadAsStringAsync();
-				return postResponse;
+				await _loggingService.Log(new LogMessage(LogSeverity.Error, nameof(ModService),
+					$"'{ModInfoUrl + name}' responded with code {response.StatusCode}"));
+				return null;
 			}
+				
+			string postResponse = await response.Content.ReadAsStringAsync();
+			return postResponse;
 		}
 	}
 }

--- a/Services/ModService.cs
+++ b/Services/ModService.cs
@@ -11,6 +11,7 @@ namespace tModloaderDiscordBot.Services
 		{
 		}
 		
+		internal const string WidgetUrl = "https://tml-readme-card.repl.co/?v=1.4&modname=";
 		private const string ModInfoUrl = "https://tmlapis.tomat.dev/1.4/mod/";
 		
 		public async Task<string> DownloadSingleData(string name)

--- a/Services/SupportChannelAutoMessageService.cs
+++ b/Services/SupportChannelAutoMessageService.cs
@@ -15,7 +15,7 @@ namespace tModloaderDiscordBot.Services
 		internal IForumChannel supportForum;
 		internal IThreadChannel supportForumPinnedThread;
 #if TESTBOT
-		private const ulong supportForumId = ;
+		private const ulong supportForumId = 1041801595454759052;
 #else
 		private const ulong supportForumId = 1019958533355229316;
 #endif
@@ -23,7 +23,7 @@ namespace tModloaderDiscordBot.Services
 		internal ITextChannel supportChannel;
 		private bool _isSetup = false;
 #if TESTBOT
-		private const ulong supportChannelId = ;
+		private const ulong supportChannelId = 1041801721405505538;
 #else
 		private const ulong supportChannelId = 871289059396448337;
 #endif

--- a/Services/SupportChannelAutoMessageService.cs
+++ b/Services/SupportChannelAutoMessageService.cs
@@ -41,7 +41,7 @@ namespace tModloaderDiscordBot.Services
 			if (!await Setup())
 				return;
 
-			if (message.Channel.Id != supportForumPinnedThread.Id)
+			if (message?.Channel?.Id != supportForumPinnedThread?.Id)
 				return;
 
 			await message.DeleteAsync();

--- a/Services/SupportChannelAutoMessageService.cs
+++ b/Services/SupportChannelAutoMessageService.cs
@@ -15,7 +15,7 @@ namespace tModloaderDiscordBot.Services
 		internal IForumChannel supportForum;
 		internal IThreadChannel supportForumPinnedThread;
 #if TESTBOT
-		private const ulong supportForumId = 1041801595454759052;
+		private const ulong supportForumId = 0;
 #else
 		private const ulong supportForumId = 1019958533355229316;
 #endif
@@ -23,7 +23,7 @@ namespace tModloaderDiscordBot.Services
 		internal ITextChannel supportChannel;
 		private bool _isSetup = false;
 #if TESTBOT
-		private const ulong supportChannelId = 1041801721405505538;
+		private const ulong supportChannelId = 0;
 #else
 		private const ulong supportChannelId = 871289059396448337;
 #endif
@@ -54,9 +54,12 @@ namespace tModloaderDiscordBot.Services
 				{
 					supportChannel = (ITextChannel)_client.GetChannel(supportChannelId);
 					supportForum = (IForumChannel)_client.GetChannel(supportForumId);
-					var activeThreads = await supportForum.GetActiveThreadsAsync();
-					supportForumPinnedThread = activeThreads.FirstOrDefault(x => x.Id == 1019968948738986064);
-					await _loggingService.Log(new LogMessage(LogSeverity.Info, "Support", $"Support pinned post {(supportForumPinnedThread == null ? "not found" : "found")}."));
+					if (supportForum != null)
+					{
+						var activeThreads = await supportForum.GetActiveThreadsAsync();
+						supportForumPinnedThread = activeThreads.FirstOrDefault(x => x.Id == 1019968948738986064);
+						await _loggingService.Log(new LogMessage(LogSeverity.Info, "Support", $"Support pinned post {(supportForumPinnedThread == null ? "not found" : "found")}."));
+					}
 					return true;
 				});
 			return _isSetup;

--- a/tModloaderDiscordBot.sln
+++ b/tModloaderDiscordBot.sln
@@ -14,10 +14,10 @@ Global
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{CD343068-B554-475F-A157-F9CCF2EF9CBB}.Debug - Test Bot|Any CPU.ActiveCfg = Debug - Test Bot|Any CPU
 		{CD343068-B554-475F-A157-F9CCF2EF9CBB}.Debug - Test Bot|Any CPU.Build.0 = Debug - Test Bot|Any CPU
-		{CD343068-B554-475F-A157-F9CCF2EF9CBB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{CD343068-B554-475F-A157-F9CCF2EF9CBB}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{CD343068-B554-475F-A157-F9CCF2EF9CBB}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{CD343068-B554-475F-A157-F9CCF2EF9CBB}.Release|Any CPU.Build.0 = Release|Any CPU
+		{CD343068-B554-475F-A157-F9CCF2EF9CBB}.Debug|Any CPU.ActiveCfg = Debug - Test Bot|Any CPU
+		{CD343068-B554-475F-A157-F9CCF2EF9CBB}.Debug|Any CPU.Build.0 = Debug - Test Bot|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
## Purpose
This PR adds commands to get 1.4 mod info. It also adds commands to get author info for version 1.3 and 1.4.

## Changes
 * `.mod` now returns 1.4 information for the given mod internal name OR mod workshop id
 * `.mod-legacy` same behavior as the old `.mod` command
 * new command `.author` returns information about a user's mods. Parameter: steam name OR steamid64
 * new command `.author-legacy` is similar to `.author`, but it returns 1.3 data
 * fixed the 1.3 widget command (now `.widget-legacy`)
 * added 1.4 widget command
 * new commands `.author-widget` and `author-widget-legacy` generate widgets which display the author's mods
 
 ## Notes
 * The commands `.mod`, `.author`, `.author-legacy`, `.widget`, `.widget-legacy`, `.author-widget` and `.author-widget-legacy` depend on a [tMLAPIs](https://github.com/NotLe0n/tMLAPIs) instance hosted on https://tmlapis.tomat.dev/. If there are any problems regarding tMLAPIs, please contact me.
* The commands `.widget`, `.widget-legacy`, `.author-widget` and `author-widget-legacy` depend on a [tml-readme-card](https://github.com/NotLe0n/tml-readme-card) instance hosted on https://tml-readme-card.repl.co/. If there are any issues with that, contact me aswell.