### PR TITLE
changed all tomat.dev and repl.co URLs to le0n.dev

### DIFF
--- a/Services/AuthorService.cs
+++ b/Services/AuthorService.cs
@@ -10,11 +10,10 @@ namespace tModloaderDiscordBot.Services
 		{
 		}
 		
-		private const string AuthorInfoUrl = "https://tmlapis.tomat.dev/1.4/author/";
-		private const string LegacyAuthorInfoUrl = "https://tmlapis.tomat.dev/1.3/author/";
-		internal const string WidgetUrl = "https://tml-readme-card.repl.co/?steamid64=";
-		internal const string LegacyWidgetUrl = "https://tml-readme-card.repl.co/?v=1.3&steamid64=";
-
+		private const string AuthorInfoUrl = "https://tmlapis.le0n.dev/1.4/author/";
+		private const string LegacyAuthorInfoUrl = "https://tmlapis.le0n.dev/1.3/author/";
+		internal const string WidgetUrl = "https://tml-card.le0n.dev/?steamid64=";
+		internal const string LegacyWidgetUrl = "https://tml-card.le0n.dev/?v=1.3&steamid64=";
 		
 		private static async Task<string> GetString(string url)
 		{

--- a/Services/LegacyModService.cs
+++ b/Services/LegacyModService.cs
@@ -18,7 +18,7 @@ namespace tModloaderDiscordBot.Services
 	{
 		internal const string QueryDownloadUrl = "http://javid.ddns.net/tModLoader/tools/querymoddownloadurl.php?modname=";
 		internal const string QueryHomepageUrl = "http://javid.ddns.net/tModLoader/tools/querymodhomepage.php?modname=";
-		internal const string WidgetUrl = "https://tml-readme-card.repl.co/?v=1.3&modname=";
+		internal const string WidgetUrl = "https://tml-card.le0n.dev/?v=1.3&modname=";
 		internal const string XmlUrl = "http://javid.ddns.net/tModLoader/listmods.php";
 		internal const string ModInfoUrl = "http://javid.ddns.net/tModLoader/tools/modinfo.php";
 		internal const string HomepageUrl = "http://javid.ddns.net/tModLoader/moddescription.php";

--- a/Services/ModService.cs
+++ b/Services/ModService.cs
@@ -22,9 +22,9 @@ namespace tModloaderDiscordBot.Services
 		{
 		}
 		
-		internal const string WidgetUrl = "https://tml-readme-card.repl.co/?v=1.4&modname=";
-		//private const string ModInfoUrl = "https://tmlapis.tomat.dev/1.4/mod/";
-		//private const string ModListUrl = "https://tmlapis.tomat.dev/1.4/list/";
+		internal const string WidgetUrl = "https://tml-card.le0n.dev/?v=1.4&modname=";
+		//private const string ModInfoUrl = "https://tmlapis.le0n.dev/1.4/mod/";
+		//private const string ModListUrl = "https://tmlapis.le0n.dev/1.4/list/";
 		
 		private static string ModDir => "mods/1.4";
 		private static Timer _updateTimer;


### PR DESCRIPTION
This fixes the .widget, .widget-legacy, .author-widget, .author-widget-legacy, author and .author-legacy commands (#39)